### PR TITLE
测试接口mindspore.mint.nn.Softmax、mindspore.mint.nn.Softshrink、mindspore.mint.nn.Dropout、mindspore.mint.nn.Linear、mindspore.mint.nn.AvgPool2d

### DIFF
--- a/test/test_AvgPool2d.py
+++ b/test/test_AvgPool2d.py
@@ -1,0 +1,151 @@
+import pytest
+import numpy as np
+import torch
+import mindspore as ms
+from mindspore import mint, Tensor
+
+
+input_data = [[[1, 6, 2, 4], [7, 3, 8, 2], [2, 9, 11, 5]],
+              [[4, 3, 1, 8], [9, 4, 3, 6], [1, 2, 7, 9]]]
+dtype_ms_list = [ms.int8, ms.int16, ms.int32, ms.int64, ms.uint8, ms.uint16, ms.uint32, ms.uint64, ms.float16,
+                 ms.float32, ms.float64, ms.bfloat16, ms.bool_]
+dtype_torch_list = [torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8, torch.uint16, torch.uint32,
+                    torch.uint64, torch.float16, torch.float32, torch.float64, torch.bfloat16, torch.bool]
+
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_avgpool2d_different_dtypes(mode):
+    """测试不同数据类型下，MindSpore和PyTorch的AvgPool2d支持度, 如果都支持，那计算结果的差异"""
+    ms.set_context(mode=mode)
+
+    for dtype_ms, dtype_torch in zip(dtype_ms_list, dtype_torch_list):
+        ms_tensor = Tensor(input_data, dtype=dtype_ms)
+        torch_tensor = torch.tensor(input_data, dtype=dtype_torch)
+
+        err = False
+        try:
+            ms_avgpool = mint.nn.AvgPool2d(kernel_size=2, stride=2)
+            ms_result = ms_avgpool(ms_tensor).asnumpy()
+        except Exception as e:
+            err = True
+            print(f"MindSpore AvgPool2d not supported for {dtype_ms}: {e}")
+
+        try:
+            torch_avgpool = torch.nn.AvgPool2d(kernel_size=2, stride=2)
+            torch_result = torch_avgpool(torch_tensor).numpy()
+        except Exception as e:
+            err = True
+            print(f"PyTorch AvgPool2d not supported for {dtype_torch}: {e}")
+
+        if not err:
+            assert np.allclose(ms_result, torch_result, atol=1e-3), f"Mismatch for dtype {dtype_ms} and {dtype_torch}"
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_avgpool2d_random_input_fixed_dtype(mode):#GRAPH_MODE problems
+    """测试固定数据类型下，不同的随机输入维度下的AvgPool2d结果一致性"""
+    ms.set_context(mode=mode)
+
+    shapes = [[5, 4, 4], [5, 4, 6, 7], [4, 5, 6, 3]]
+    for shape in shapes:
+        ms_tensor = Tensor(np.random.randn(*shape), dtype=ms.float32)
+        torch_tensor = torch.tensor(ms_tensor.asnumpy(), dtype=torch.float32)
+
+        ms_avgpool = mint.nn.AvgPool2d(kernel_size=2, stride=2)
+        torch_avgpool = torch.nn.AvgPool2d(2, stride=2)
+
+        ms_result = ms_avgpool(ms_tensor).asnumpy()
+        torch_result = torch_avgpool(torch_tensor).numpy()
+
+        assert np.allclose(ms_result, torch_result, atol=1e-3), f"Mismatch for shape {shape}"
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_avgpool2d_different_params(mode):#GRAPH_MODE problems
+    """测试MindSpore和PyTorch中AvgPool2d的不同kernel_size, stride, padding等参数支持度"""
+    ms.set_context(mode=mode)
+
+    params = [(2, 2, 0), (3, 3, 1), (2, 1, 1)]
+    for kernel_size, stride, padding in params:
+        ms_tensor = Tensor(input_data, dtype=ms.float32)
+        torch_tensor = torch.tensor(input_data, dtype=torch.float32)
+
+        ms_avgpool = mint.nn.AvgPool2d(kernel_size=kernel_size, stride=stride, padding=padding)
+        torch_avgpool = torch.nn.AvgPool2d(kernel_size, stride, padding=padding)
+
+        ms_result = ms_avgpool(ms_tensor).asnumpy()
+        torch_result = torch_avgpool(torch_tensor).numpy()
+
+        assert np.allclose(ms_result, torch_result, atol=1e-3), f"Mismatch for kernel_size={kernel_size}, stride={stride}, padding={padding}"
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_avgpool2d_wrong_input(mode):
+    """测试无效输入时，MindSpore和PyTorch的错误处理"""
+    ms.set_context(mode=mode)
+
+    ms_tensor = Tensor(input_data, dtype=ms.float32)
+    torch_tensor = torch.tensor(input_data, dtype=torch.float32)
+
+    try:
+        ms_avgpool = mint.nn.AvgPool2d(kernel_size=10, stride=2)
+        ms_result = ms_avgpool(ms_tensor).asnumpy()  # 错误的kernel_size
+    except Exception as e:
+        print(f"MindSpore AvgPool2d error: {e}")
+
+    try:
+        torch_avgpool = torch.nn.AvgPool2d(kernel_size=10, stride=2)
+        torch_result = torch_avgpool(torch_tensor)  # 错误的kernel_size
+    except Exception as e:
+        print(f"PyTorch AvgPool2d error: {e}")
+
+    try:
+        ms_avgpool = mint.nn.AvgPool2d(kernel_size=2, stride=3)
+        ms_result = ms_avgpool(ms_tensor)  # 错误的stride
+    except Exception as e:
+        print(f"MindSpore AvgPool2d stride error: {e}")
+
+    try:
+        torch_avgpool = torch.nn.AvgPool2d(kernel_size=2, stride=3)
+        torch_result = torch_avgpool(torch_tensor)  # 错误的stride
+    except Exception as e:
+        print(f"PyTorch AvgPool2d stride error: {e}")
+
+def sum_avgpool2d_output(tensor, kernel_size, stride, padding):
+    '''利用ms.ops.grad获取mindspore计算的梯度'''
+    avgpool = mint.nn.AvgPool2d(kernel_size=kernel_size, stride=stride, padding=padding)
+    return avgpool(tensor).sum()
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_avgpool2d_mint_forward_back(mode):#GRAPH_MODE problems
+    """使用Pytorch和MindSpore, 固定输入和权重, 测试正向推理结果和反向梯度"""
+    ms.set_context(mode=mode)
+
+    # MindSpore setup
+    ms_tensor = Tensor(input_data, ms.float32)
+    ms_avgpool = mint.nn.AvgPool2d(kernel_size=2, stride=2)
+
+    # Forward pass
+    ms_result = ms_avgpool(ms_tensor)
+
+    # Using ms.ops.grad to compute the gradients
+    gradient_function = ms.ops.grad(sum_avgpool2d_output)
+    grad_ms = gradient_function(ms_tensor, 2, 2, 0)
+
+
+    torch_result = np.array([[[4.25, 4.]], [[5., 4.5]]], dtype=np.float32)
+    grad_torch = np.array([[[0.25, 0.25, 0.25, 0.25],
+                              [0.25, 0.25, 0.25, 0.25],
+                              [0., 0., 0., 0.]],
+
+                             [[0.25, 0.25, 0.25, 0.25],
+                              [0.25, 0.25, 0.25, 0.25],
+                              [0., 0., 0., 0.]]], dtype=np.float32)
+    # Check forward pass results
+    assert np.allclose(ms_result.asnumpy(), torch_result,
+                       atol=1e-3), "Forward outputs differ more than allowed tolerance"
+
+    # Check gradients
+    assert np.allclose(grad_ms.asnumpy(), grad_torch, atol=1e-3), "Gradients differ more than allowed tolerance"

--- a/test/test_Dropout.py
+++ b/test/test_Dropout.py
@@ -1,0 +1,85 @@
+import pytest
+import torch
+import numpy as np
+import mindspore as ms
+from mindspore import mint, Tensor
+
+input_data = np.random.rand(10, 20, 30) 
+dropout_rate = 0.5 
+
+ms_tensor = Tensor(input_data, ms.float32)
+torch_tensor = torch.tensor(input_data, dtype=torch.float32)
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_dropout_train_eval(mode):
+    """测试训练模式和评估模式下的Dropout表现"""
+    ms.set_context(mode=mode)
+
+    # MindSpore Dropout
+    dropout_ms = mint.nn.Dropout(p=dropout_rate)
+
+    dropout_ms.set_train()  
+    ms_output_train = dropout_ms(ms_tensor)
+    dropout_ms.set_train(False)
+    ms_output_eval = dropout_ms(ms_tensor)
+    np_array = np.array(input_data)
+    # 检查训练模式和评估模式下的输出差异
+    # print("Dropout之前的数据是：")
+    # print(ms_tensor)
+    # print("Dropout在train模式下的结果如下：")
+    # print(ms_output_train)
+
+    assert np.allclose(np_array, ms_output_eval.asnumpy(),
+                           atol=1e-3), "Mindspore Dropout behavior in training mode is not as expected, eval also dropout"
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_dropout_sparse_in_training(mode):
+    """测试训练模式下的Dropout稀疏性"""
+    ms.set_context(mode=mode)
+
+    # MindSpore Dropout
+    dropout_ms = mint.nn.Dropout(p=dropout_rate)
+    dropout_ms.set_train()
+    # PyTorch Dropout
+    dropout_torch = torch.nn.Dropout(p=dropout_rate)
+
+    ms_output_train = dropout_ms(ms_tensor)
+    print(ms_output_train)
+    print("((*(*(")
+    torch_output_train = dropout_torch(torch_tensor)
+
+    ms_nonzero = np.count_nonzero(ms_output_train.asnumpy())
+    torch_nonzero = torch.count_nonzero(torch_output_train).item()
+
+    # 对比是否丢弃了接近50%的神经元（考虑到一定的随机性）
+    ms_nonzero_ratio = ms_nonzero / ms_output_train.size
+    torch_nonzero_ratio = torch_nonzero / torch_output_train.numel()
+
+    assert not abs(1 - ms_nonzero_ratio - dropout_rate) < 0.1, f"MindSpore的Dropout之后剩余的比例: {ms_nonzero_ratio}"
+
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_dropout_reproducibility(mode):
+    """测试Dropout的可重复性（相同输入是否得到相同的输出）"""
+    ms.set_context(mode=mode)
+
+    # MindSpore Dropout
+    dropout_ms = mint.nn.Dropout(p=dropout_rate)
+    dropout_ms.set_train()
+    # PyTorch Dropout
+    dropout_torch = torch.nn.Dropout(p=dropout_rate)
+
+    ms_output_1 = dropout_ms(ms_tensor)
+    ms_output_2 = dropout_ms(ms_tensor)
+
+    torch_output_1 = dropout_torch(torch_tensor)
+    torch_output_2 = dropout_torch(torch_tensor)
+
+    assert not np.allclose(ms_output_1.asnumpy(), ms_output_2.asnumpy(),
+                           atol=1e-3), "MindSpore Dropout results should differ between different calls"
+    assert not np.allclose(torch_output_1.detach().numpy(), torch_output_2.detach().numpy(),
+                           atol=1e-3), "PyTorch Dropout results should differ between different calls"
+

--- a/test/test_Linear.py
+++ b/test/test_Linear.py
@@ -1,0 +1,212 @@
+import pytest
+import numpy as np
+import torch
+import mindspore as ms
+from mindspore import mint, Tensor
+
+
+input_data = [[1, 6, 2, 4], [7, 3, 8, 2], [2, 9, 11, 5]]
+dtype_ms_list = [ms.int8, ms.int16, ms.int32, ms.int64, ms.uint8, ms.uint16, ms.uint32, ms.uint64, ms.float16,
+                 ms.float32, ms.float64, ms.bfloat16, ms.bool_]
+dtype_torch_list = [torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8, torch.uint16, torch.uint32,
+                    torch.uint64, torch.float16, torch.float32, torch.float64, torch.bfloat16, torch.bool]
+
+
+def sum_linear_output(tensor, weight, bias=None):
+    '''利用ms.ops.grad获取mindspore计算的梯度'''
+    linear = mint.nn.Linear(in_features=tensor.shape[1], out_features=weight.shape[0])
+    return linear(tensor).sum()
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_linear_different_dtypes(mode):
+    """测试不同数据类型下，MindSpore和PyTorch的Linear支持度, 如果都支持，那计算结果的差异"""
+    ms.set_context(mode=mode)
+
+    for dtype_ms, dtype_torch in zip(dtype_ms_list, dtype_torch_list):
+        ms_tensor = Tensor(input_data, dtype=dtype_ms)
+        torch_tensor = torch.tensor(input_data, dtype=dtype_torch)
+
+        err = False
+        try:
+            ms_linear = mint.nn.Linear(in_features=4, out_features=3)  # 4输入，3输出
+            ms_result = ms_linear(ms_tensor).asnumpy()
+        except Exception as e:
+            err = True
+            print(f"MindSpore Linear not supported for {dtype_ms}: {e}")
+
+        try:
+            torch_linear = torch.nn.Linear(4, 3)
+            torch_result = torch_linear(torch_tensor).detach().numpy()
+        except Exception as e:
+            err = True
+            print(f"PyTorch Linear not supported for {dtype_torch}: {e}")
+        #不在这里测试，固定w和b在test_linear_mint_forward_back中测试
+        #if not err:
+        #    assert np.allclose(ms_result, torch_result, atol=1e-3), f"Mismatch for dtype {dtype_ms} and {dtype_torch}"
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_linear_mint_forward_back(mode):
+    """使用Pytorch和MindSpore, 固定输入和权重, 测试正向推理结果和反向梯度"""
+    ms.set_context(mode=mode)
+
+    # MindSpore setup
+    input_data = np.array([[1, 6, 2, 4], [7, 3, 8, 2], [2, 9, 11, 5]], dtype=np.float32)  # shape: (3, 4)
+
+    # 固定权重和偏置
+    weight_init = np.array([[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8], [0.9, 1.0, 1.1, 1.2]],
+                           dtype=np.float32)  # 权重: (3, 4)
+    bias_init = np.array([0.1, 0.2, 0.3], dtype=np.float32)  
+
+    ms_tensor = Tensor(input_data, ms.float32)
+    ms_linear = mint.nn.Linear(in_features=4, out_features=3,
+                               weight_init=Tensor(weight_init), bias_init=Tensor(bias_init))
+    ms_result = ms_linear(ms_tensor)
+    print(ms_result)
+
+    gradient_function = ms.ops.grad(ms_linear)
+    grad_ms = gradient_function(ms_tensor)
+
+    torch_result_target = np.array([[3.6, 8.900001, 14.2],
+                                    [4.6000004, 12.700001, 20.800001],
+                                    [7.4, 18.300001, 29.2]], dtype=np.float32)
+
+    grad_torch_target = np.array([[1.5, 1.8, 2.1, 2.4],
+                                  [1.5, 1.8, 2.1, 2.4],
+                                  [1.5, 1.8, 2.1, 2.4]], dtype=np.float32)
+
+    # Check forward pass results
+    assert np.allclose(ms_result.asnumpy(), torch_result_target,
+                       atol=1e-3), "Forward outputs differ more than allowed tolerance"
+
+    # Check gradients
+    assert np.allclose(grad_ms.asnumpy(), grad_torch_target, atol=1e-3), "Gradients differ more than allowed tolerance"
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_linear_random_input_fixed_dtype(mode):
+    """测试固定数据类型下，不同的随机输入维度下的Linear结果一致性"""
+    ms.set_context(mode=mode)
+
+    shapes = [[5, 4], [5, 4, 2], [5, 4, 3, 2]]
+
+    for shape in shapes:
+        ms_tensor = Tensor(np.random.randn(*shape), dtype=ms.float32)
+        torch_tensor = torch.tensor(ms_tensor.asnumpy(), dtype=torch.float32)
+        weight = np.random.randn(shape[-1], 3).astype(np.float32)
+        bias = np.random.randn(3).astype(np.float32) 
+        ms_linear = mint.nn.Linear(in_features=shape[-1], out_features=3, weight_init=Tensor(weight),
+                                   bias_init=Tensor(bias))
+        torch_linear = torch.nn.Linear(shape[-1], 3)
+
+        with torch.no_grad():
+            torch_linear.weight.copy_(torch.tensor(weight))
+            torch_linear.bias.copy_(torch.tensor(bias))
+
+
+        ms_result = ms_linear(ms_tensor).asnumpy()
+        torch_result = torch_linear(torch_tensor).detach().numpy()
+        assert np.allclose(ms_result, torch_result, atol=1e-3), f"Mismatch for shape {shape}"
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_linear_different_params(mode):
+    """测试MindSpore和PyTorch中Linear层的不同in_features和out_features参数支持度"""
+    ms.set_context(mode=mode)
+
+    params = [(4, 3), (5, 2), (6, 10)]
+    for in_features, out_features in params:
+        ms_tensor = Tensor(input_data, dtype=ms.float32)
+        torch_tensor = torch.tensor(input_data, dtype=torch.float32)
+
+        ms_linear = mint.nn.Linear(in_features=in_features, out_features=out_features)
+        torch_linear = torch.nn.Linear(in_features, out_features)
+
+        ms_result = ms_linear(ms_tensor).asnumpy()
+        torch_result = torch_linear(torch_tensor).detach().numpy()
+
+
+        assert np.allclose(ms_result, torch_result,
+                           atol=1e-3), f"Mismatch for in_features={in_features} and out_features={out_features}"
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_linear_wrong_input(mode):
+    """测试无效输入时，MindSpore和PyTorch的错误处理"""
+    ms.set_context(mode=mode)
+
+    ms_tensor = Tensor(input_data, dtype=ms.float32)
+    torch_tensor = torch.tensor(input_data, dtype=torch.float32)
+
+    try:
+        ms_linear = mint.nn.Linear(in_features=4, out_features=3)
+        ms_result = ms_linear(ms_tensor).asnumpy() 
+    except Exception as e:
+        print(f"MindSpore Linear error: {e}")
+
+    try:
+        weight_init = np.random.randn(3, 4).astype(np.float32)  
+        bias_init = np.random.randn(3).astype(np.float32) 
+        ms_linear = mint.nn.Linear(in_features=4, out_features=3, weight_init=weight_init, bias_init=bias_init)
+        ms_result = ms_linear(ms_tensor).asnumpy() 
+        print(f"MindSpore Linear with correct weight_init and bias_init output: {ms_result}")
+    except Exception as e:
+        print(f"MindSpore Linear weight_init/bias_init error: {e}")
+
+    try:
+        weight_init = np.random.randn(4, 3).astype(np.float32)
+        bias_init = np.random.randn(4).astype(np.float32) 
+        ms_linear = mint.nn.Linear(in_features=4, out_features=3, weight_init=Tensor(weight_init),
+                                   bias_init=Tensor(bias_init))
+        ms_result = ms_linear(ms_tensor)  
+    except Exception as e:
+        print(f"MindSpore Linear incorrect weight_init/bias_init shape error: {e}")
+
+    try:
+        incorrect_input_data = [[1, 6], [7, 3], [2, 9]] 
+        incorrect_ms_tensor = Tensor(incorrect_input_data, dtype=ms.float32)
+        ms_linear = mint.nn.Linear(in_features=4, out_features=3)
+        ms_result = ms_linear(incorrect_ms_tensor)  
+    except Exception as e:
+        print(f"MindSpore Linear incorrect input shape error: {e}")
+
+    try:
+        torch_linear = torch.nn.Linear(in_features=4, out_features=3)
+        torch_result = torch_linear(torch_tensor) 
+    except Exception as e:
+        print(f"PyTorch Linear error: {e}")
+
+    try:
+        weight_init = np.random.randn(3, 4).astype(np.float32)  
+        bias_init = np.random.randn(3).astype(np.float32) 
+        torch_linear = torch.nn.Linear(in_features=4, out_features=3)
+        torch_linear.weight.data = torch.tensor(weight_init)
+        torch_linear.bias.data = torch.tensor(bias_init) 
+        torch_result = torch_linear(torch_tensor)  
+        print(f"PyTorch Linear with correct weight_init and bias_init output: {torch_result}")
+    except Exception as e:
+        print(f"PyTorch Linear weight_init/bias_init error: {e}")
+
+    try:
+        weight_init = np.random.randn(4, 3).astype(np.float32) 
+        bias_init = np.random.randn(4).astype(np.float32) 
+        torch_linear = torch.nn.Linear(in_features=4, out_features=3)
+        torch_linear.weight.data = torch.tensor(weight_init) 
+        torch_linear.bias.data = torch.tensor(bias_init) 
+        torch_result = torch_linear(torch_tensor) 
+    except Exception as e:
+        print(f"PyTorch Linear incorrect weight_init/bias_init shape error: {e}")
+
+    try:
+        incorrect_input_data = [[1, 6], [7, 3], [2, 9]]
+        incorrect_torch_tensor = torch.tensor(incorrect_input_data, dtype=torch.float32)
+        torch_linear = torch.nn.Linear(in_features=4, out_features=3)
+        torch_result = torch_linear(incorrect_torch_tensor) 
+    except Exception as e:
+        print(f"PyTorch Linear incorrect input shape error: {e}")
+
+
+
+
+

--- a/test/test_Softmax.py
+++ b/test/test_Softmax.py
@@ -1,0 +1,129 @@
+import pytest
+import numpy as np
+import torch
+import mindspore as ms
+from mindspore import mint, Tensor, value_and_grad
+
+
+input_data = [[1, 6, 2, 4], [7, 3, 8, 2], [2, 9, 11, 5]]
+dtype_ms_list = [ms.int8, ms.int16, ms.int32, ms.int64, ms.uint8, ms.uint16, ms.uint32, ms.uint64, ms.float16,
+                 ms.float32, ms.float64, ms.bfloat16, ms.bool_]
+dtype_torch_list = [torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8, torch.uint16, torch.uint32,
+                    torch.uint64, torch.float16, torch.float32, torch.float64, torch.bfloat16, torch.bool]
+
+def sum_softmax_output(tensor):
+    '''利用ms.ops.grad获取mindspore计算的梯度'''
+    softmax = mint.nn.Softmax(dim=-1)
+    return softmax(tensor).sum()
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_softmax_different_dtypes(mode):
+    """测试不同数据类型下，MindSpore和PyTorch的Softmax支持度,如果都支持，那计算结果的差异"""
+    ms.set_context(mode=mode)
+
+    for dtype_ms, dtype_torch in zip(dtype_ms_list, dtype_torch_list):
+        ms_tensor = Tensor(input_data, dtype=dtype_ms)
+        torch_tensor = torch.tensor(input_data, dtype=dtype_torch)
+
+        err = False
+        try:
+            ms_result = mint.nn.Softmax(dim=-1)(ms_tensor).asnumpy()
+        except Exception as e:
+            err = True
+            print(f"MindSpore Softmax not supported for {dtype_ms}")
+
+        try:
+            torch_result = torch.softmax(torch_tensor, dim=-1).numpy()
+        except Exception as e:
+            err = True
+            print(f"PyTorch Softmax not supported for {dtype_torch}")
+
+        if not err:
+            assert np.allclose(ms_result, torch_result, atol=1e-3)
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_softmax_random_input_fixed_dtype(mode):
+    """测试固定数据类型下，不同的随机输入维度下的Softmax结果一致性"""
+    ms.set_context(mode=mode)
+
+    shapes = [[5], [5, 2], [5, 4, 3], [4, 6, 7, 8]]
+    for shape in shapes:
+        ms_tensor = Tensor(np.random.randn(*shape), dtype=ms.float32)
+        torch_tensor = torch.tensor(ms_tensor.asnumpy(), dtype=torch.float32)
+
+        ms_result = mint.nn.Softmax(dim=-1)(ms_tensor).asnumpy()
+        torch_result = torch.softmax(torch_tensor, dim=-1).numpy()
+
+        assert np.allclose(ms_result, torch_result, atol=1e-3)
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_softmax_different_params(mode):
+    """测试MindSpore和PyTorch中Softmax的不同dim参数支持度"""
+    ms.set_context(mode=mode)
+
+    # 测试不同dim参数
+    axes = [None, 0, 1, -1] 
+    for axis in axes:
+        # MindSpore Softmax
+        if axis is None:
+            ms_softmax = mint.nn.Softmax(dim=-1)  # MindSpore不支持None作为axis，使用-1作为等效
+        else:
+            ms_softmax = mint.nn.Softmax(dim=axis)
+        ms_tensor = Tensor(input_data, dtype=ms.float32)
+        ms_result = ms_softmax(ms_tensor).asnumpy()
+
+        # PyTorch Softmax
+        if axis is None:
+            axis = -1  # PyTorch也使用-1来表示最后一个维度
+        torch_tensor = torch.tensor(input_data, dtype=torch.float32)
+        torch_result = torch.softmax(torch_tensor, dim=axis).numpy()
+        assert np.allclose(ms_result, torch_result, atol=1e-3), f"Mismatch in results for dim {axis}"
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_softmax_wrong_input(mode):
+    """测试无效输入时，MindSpore和PyTorch的错误处理"""
+    ms.set_context(mode=mode)
+
+    ms_tensor = Tensor(input_data, dtype=ms.float32)
+    torch_tensor = torch.tensor(input_data, dtype=torch.float32)
+
+    try:
+        ms_result = mint.nn.Softmax(dim=10)(ms_tensor).asnumpy() 
+    except Exception as e:
+        print(f"MindSpore Softmax axis超出范围的错误信息：\n{e}")
+
+    try:
+        torch_result = torch.softmax(torch_tensor, dim=10)
+    except Exception as e:
+        print(f"PyTorch Softmax axis超出范围的错误信息：\n{e}")
+
+
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_softmax_mint_forward_back(mode):
+    """使用Pytorch和MindSpore, 固定输入和权重, 测试正向推理结果和反向梯度"""
+    ms.set_context(mode=mode)
+
+
+    ms_tensor = Tensor(input_data, ms.float32)
+    softmax_ms = mint.nn.Softmax(dim=-1)
+    torch_tensor = torch.tensor(input_data, dtype=torch.float32, requires_grad=True)
+    softmax_torch = torch.nn.Softmax(dim=-1)
+    output_ms = softmax_ms(ms_tensor)
+    output_torch = softmax_torch(torch_tensor)
+    gradient_function = ms.ops.grad(sum_softmax_output)
+    grad_ms = gradient_function(ms_tensor)
+
+    loss_torch = output_torch.sum()
+    loss_torch.backward()
+
+    grad_torch = torch_tensor.grad
+
+    assert np.allclose(output_ms.asnumpy(), output_torch.detach().numpy(),
+                       atol=1e-3), "Forward outputs differ more than allowed tolerance"
+
+    assert np.allclose(grad_ms.asnumpy(), grad_torch.numpy(), atol=1e-3), "Gradients differ more than allowed tolerance"

--- a/test/test_Softshrink.py
+++ b/test/test_Softshrink.py
@@ -1,0 +1,131 @@
+import pytest
+import numpy as np
+import torch
+import mindspore as ms
+from mindspore import mint, Tensor
+
+input_data = [[1, 6, 2, 4], [7, 3, 8, 2], [2, 9, 11, 5]]
+dtype_ms_list = [ms.int8, ms.int16, ms.int32, ms.int64, ms.uint8, ms.uint16, ms.uint32, ms.uint64, ms.float16,
+                 ms.float32, ms.float64, ms.bfloat16, ms.bool_]
+dtype_torch_list = [torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8, torch.uint16, torch.uint32,
+                    torch.uint64, torch.float16, torch.float32, torch.float64, torch.bfloat16, torch.bool]
+
+
+def sum_softshrink_output(tensor, lambd=0.5):
+    '''利用ms.ops.grad获取mindspore计算的梯度'''
+    softshrink = mint.nn.Softshrink(lambd=lambd)
+    return softshrink(tensor).sum()
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_softshrink_different_dtypes(mode):
+    """测试不同数据类型下，MindSpore和PyTorch的Softshrink支持度, 如果都支持，那计算结果的差异"""
+    ms.set_context(mode=mode)
+
+    for dtype_ms, dtype_torch in zip(dtype_ms_list, dtype_torch_list):
+        ms_tensor = Tensor(input_data, dtype=dtype_ms)
+        torch_tensor = torch.tensor(input_data, dtype=dtype_torch)
+
+        err = False
+        try:
+            ms_result = mint.nn.Softshrink(lambd=0.5)(ms_tensor).asnumpy()
+        except Exception as e:
+            err = True
+            print(f"MindSpore Softshrink not supported for {dtype_ms}")
+
+        try:
+            torch_result = torch.nn.functional.softshrink(torch_tensor, lambd=0.5).numpy()
+        except Exception as e:
+            err = True
+            print(f"PyTorch Softshrink not supported for {dtype_torch}")
+
+        if not err:
+            assert np.allclose(ms_result, torch_result, atol=1e-3)
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_softshrink_random_input_fixed_dtype(mode):
+    """测试固定数据类型下，不同的随机输入维度下的Softshrink结果一致性"""
+    ms.set_context(mode=mode)
+
+    shapes = [[5], [5, 2], [5, 4, 3], [4, 6, 7, 8]]
+    for shape in shapes:
+        ms_tensor = Tensor(np.random.randn(*shape), dtype=ms.float32)
+        torch_tensor = torch.tensor(ms_tensor.asnumpy(), dtype=torch.float32)
+
+        ms_result = mint.nn.Softshrink(lambd=0.5)(ms_tensor).asnumpy()
+        torch_result = torch.nn.functional.softshrink(torch_tensor, lambd=0.5).numpy()
+
+        assert np.allclose(ms_result, torch_result, atol=1e-3)
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_softshrink_different_params(mode):
+    """测试MindSpore和PyTorch中Softshrink的不同lambd参数支持度"""
+    ms.set_context(mode=mode)
+
+    lambds = [0.1, 0.5, 1.0, 2.0]
+    for lambd in lambds:
+        # MindSpore Softshrink
+        ms_tensor = Tensor(input_data, dtype=ms.float32)
+        ms_result = mint.nn.Softshrink(lambd=lambd)(ms_tensor).asnumpy()
+
+        # PyTorch Softshrink
+        torch_tensor = torch.tensor(input_data, dtype=torch.float32)
+        torch_result = torch.nn.functional.softshrink(torch_tensor, lambd=lambd).numpy()
+
+        # 断言两个框架的结果一致
+        assert np.allclose(ms_result, torch_result, atol=1e-3), f"Mismatch in results for lambd {lambd}"
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_softshrink_wrong_input(mode):
+    """测试无效输入时，MindSpore和PyTorch的错误处理"""
+    ms.set_context(mode=mode)
+
+    ms_tensor = Tensor(input_data, dtype=ms.float32)
+    torch_tensor = torch.tensor(input_data, dtype=torch.float32)
+
+    try:
+        ms_result = mint.nn.Softshrink(lambd=0.5)(ms_tensor).asnumpy()  # 有效
+    except Exception as e:
+        print(f"MindSpore Softshrink error: {e}")
+
+    try:
+        torch_result = torch.nn.functional.softshrink(torch_tensor, lambd=0.5).numpy()  # 有效
+    except Exception as e:
+        print(f"PyTorch Softshrink error: {e}")
+
+    try:
+        ms_result = mint.nn.Softshrink(lambd=-10)(ms_tensor).asnumpy()  
+    except Exception as e:
+        print(f"MindSpore Softshrink invalid lambd error: {e}")
+
+    try:
+        torch_result = torch.nn.functional.softshrink(torch_tensor, lambd=-10).numpy()  
+    except Exception as e:
+        print(f"PyTorch Softshrink invalid lambd error: {e}")
+
+
+@pytest.mark.parametrize('mode', [ms.GRAPH_MODE, ms.PYNATIVE_MODE])
+def test_softshrink_mint_forward_back(mode):
+    """使用Pytorch和MindSpore, 固定输入和权重, 测试正向推理结果和反向梯度"""
+    ms.set_context(mode=mode)
+
+    ms_tensor = Tensor(input_data, ms.float32)
+    softshrink_ms = mint.nn.Softshrink(lambd=0.5)
+    torch_tensor = torch.tensor(input_data, dtype=torch.float32, requires_grad=True)
+    softshrink_torch = torch.nn.functional.softshrink(torch_tensor, lambd=0.5)
+
+    output_ms = softshrink_ms(ms_tensor)
+    output_torch = softshrink_torch
+
+    gradient_function = ms.ops.grad(sum_softshrink_output)
+    grad_ms = gradient_function(ms_tensor)
+
+    output_torch.sum().backward()
+    grad_torch = torch_tensor.grad
+
+    assert np.allclose(output_ms.asnumpy(), output_torch.detach().numpy(),
+                       atol=1e-3), "Forward outputs differ more than allowed tolerance"
+    assert np.allclose(grad_ms.asnumpy(), grad_torch.numpy(), atol=1e-3), "Gradients differ more than allowed tolerance"


### PR DESCRIPTION
相关测试问题已经提交到mindspore的gitee上了
1. [有关于mint.nn.Linear的报错信息不如Pytorch简洁](https://gitee.com/mindspore/mindspore/issues/IBBDJ0)
2. [Mindspore2.4.1最新版在Ascend910A上安装报错](https://gitee.com/mindspore/mindspore/issues/IBAZIQ#note_35421264)
3. [mindspore.mint.nn.AvgPool2d不支持float64和int64](https://gitee.com/mindspore/mindspore/issues/IBBDHD)
4. [mint.nn.AvgPool2d参数不对，未和Pytorch对齐](https://gitee.com/mindspore/mindspore/issues/IBBDH2)
5. [mint.nn.Dropout官网API的样例GRAPH_MODE下计算图编译不出来](https://gitee.com/mindspore/mindspore/issues/IBBDGD)